### PR TITLE
fix(migrations): complete down migration for rsvp.server_read_cursor

### DIFF
--- a/migrations/20221008223416_reservation_trigger.down.sql
+++ b/migrations/20221008223416_reservation_trigger.down.sql
@@ -1,3 +1,4 @@
 DROP TRIGGER reservations_trigger ON rsvp.reservations;
 DROP FUNCTION rsvp.reservations_trigger();
 DROP TABLE rsvp.reservation_changes CASCADE;
+DROP TABLE rsvp.server_read_cursor CASCADE;


### PR DESCRIPTION
Add missing DROP TABLE CASCADE statement to ensure the down migration correctly reverts the schema changes.